### PR TITLE
Update styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,3 @@
-div[role=gridcell] span {
-    white-space: normal !important;
+div[role="gridcell"] span {
+  white-space: normal !important;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,3 @@
-.b6ax4al1 {
-  height: auto !important;
-  overflow: visible !important;
-  white-space: pre-line !important;
+div[role=gridcell] span {
+    white-space: normal !important;
 }


### PR DESCRIPTION
FB has updated either their generated CSS classnames or their entire layout, and extendo-chat's intended functionality to display entire messages no longer works. 

This PR updates the styling overrides to use a more generic selector not dependent on a generated class name.